### PR TITLE
Add rutracker support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 **/__pycache__
-config/torrentino.yaml
 logs/
+config/torrentino.yaml
+.env
+compose.yaml
+.cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:slim
+FROM python:3.11-slim
 
 RUN groupadd -g 2022 python && \
     useradd -g 2022 -u 2022 --create-home --home-dir /usr/src/app python

--- a/Dockerfile.nas
+++ b/Dockerfile.nas
@@ -1,4 +1,4 @@
-FROM python:slim
+FROM python:3.11-slim
 
 RUN groupadd -g 2022 python && \
     useradd -g 2022 -u 2022 --create-home --home-dir /usr/src/app python

--- a/Dockerfile.nas
+++ b/Dockerfile.nas
@@ -1,0 +1,24 @@
+FROM python:slim
+
+RUN groupadd -g 2022 python && \
+    useradd -g 2022 -u 2022 --create-home --home-dir /usr/src/app python
+
+USER python
+WORKDIR /usr/src/app
+
+ENV PATH="${PATH}:/usr/src/app/.local/bin:/usr/src/app"
+
+COPY Pipfile Pipfile.lock ./
+
+RUN pip install --user pipenv && \
+    pipenv install
+
+COPY lib lib
+COPY models models
+COPY torrentino.py .
+
+RUN mkdir -p ./config
+COPY config/torrentino.yaml /usr/src/app/config/torrentino.yaml
+
+ENTRYPOINT [ "pipenv", "run", "./torrentino.py" ]
+# ENTRYPOINT [ "/bin/bash"]

--- a/Dockerfile.nas
+++ b/Dockerfile.nas
@@ -21,4 +21,3 @@ RUN mkdir -p ./config
 COPY config/torrentino.yaml /usr/src/app/config/torrentino.yaml
 
 ENTRYPOINT [ "pipenv", "run", "./torrentino.py" ]
-# ENTRYPOINT [ "/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Additionally you could setup home DLNA server like Jellyfin, Plex or MiniDLNA an
 * http://rutor.info 
 * https://kat.sx/
 * https://toloka.to
+* https://rutracker.to
 
 (new will arrive soon)
 
@@ -54,6 +55,7 @@ Additionally you could setup home DLNA server like Jellyfin, Plex or MiniDLNA an
 3. Register accounts on torrent trackers (credentials needs to be added to configuration file later):
    * http://nnmclub.to
    * https://toloka.to
+   * https://rutracker.to
 
 ## Run bot locally
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ Additionally you could setup home DLNA server like Jellyfin, Plex or MiniDLNA an
    ```
 5. Check container logs.
 
+Optionally you can build an image chat includes the torrention.yaml using
+   ```
+   docker build -f Dockerfile.nas -t my-bot . 
+   ```
+
 
 **Complete installation Guide for Raspberry Pi 4 can be found at [Home DLNA on Raspberry Pi4 setup guide](doc/Home-DNLA-setup.md)**
 

--- a/README.md
+++ b/README.md
@@ -62,10 +62,12 @@ Additionally you could setup home DLNA server like Jellyfin, Plex or MiniDLNA an
 1. Clone this repository
    ```
    git clone https://github.com/adskyiproger/transmission-telegram-bot.git
+   cd transmission-telegram-bot
    ```
    or download as zip file: https://github.com/adskyiproger/transmission-telegram-bot/archive/refs/heads/master.zip
 2. Update config/torrentino.yaml configuration file. Follow up comments inside configuration file:
    ```
+   mkdir -p config
    cp templates/torrentino.sample.yaml config/torrentino.yaml
    nano config/torrentino.yaml
    ```

--- a/models/PostsBrowser.py
+++ b/models/PostsBrowser.py
@@ -13,7 +13,8 @@ class PostsBrowser(Browser):
         # Add first and last posts index
         post_num = (page - 1) * self.posts_per_page
         for post in self.posts[post_num:post_num+self.posts_per_page]:
-            _message += f"\n<b>{post['title']}</b>: {post['size']}  {post['date']} ⬆{post['seed']} ⬇{post['leach']}\n" \
-                        f"<a href='{post['info']}'>Info</a>     [ ▼ /download_{post_num} ]\n"
+            _message += f"\n<b>{post['title']}</b>: \n" \
+                        f"{post['size']}  {post['date']} ⬆{post['seed']} ⬇{post['leach']}\n" \
+                        f"<a href='{post['info']}'>{post['tracker']}</a>     [ ▼ /download_{post_num} ]\n"
             post_num += 1
         return _message

--- a/models/SearchBase.py
+++ b/models/SearchBase.py
@@ -1,6 +1,9 @@
 import requests
 from typing import List
 from lib.func import get_logger, save_torrent_to_tempfile
+from models.BotConfigurator import BotConfigurator
+
+bot_config = BotConfigurator()
 
 class SearchBase:
     LOGGED_IN = False
@@ -23,13 +26,36 @@ class SearchBase:
         if self._session:
             return self._session
 
+
         self._session = requests.Session()
+        self._session.headers.update(
+            {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.5563.65 Safari/537.36'})
+
+        # this helps debugging
+        if bot_config.get('proxy.enabled'):
+            proxies = {}
+            if bot_config.get('proxy.url'):
+                proxies['http'] = bot_config.get('proxy.url')
+                proxies['https'] = bot_config.get('proxy.url')
+            self._session.proxies.update(proxies)
+            self._session.verify = False
+
         self.log.debug("%s %s", self.username, self.password)
         if self.TRACKER_LOGIN_URL:
             self.log.info("Loggin in %s", self.TRACKER_LOGIN_URL)
+            username_field = "username"
+            password_field = "password"
+
+            try:
+                if self.TRACKER_LOGIN_FIELDS:
+                    username_field = self.TRACKER_LOGIN_FIELDS['username']
+                    password_field = self.TRACKER_LOGIN_FIELDS['password']
+            except Exception as e:
+                self.log.warning(e)
+                pass
             payload = {
-                "username": self.username,
-                "password": self.password,
+                username_field: self.username,
+                password_field: self.password,
                 'redirect': 'index.php?',
                 'sid': '',
                 'login': 'Login'

--- a/models/SearchBase.py
+++ b/models/SearchBase.py
@@ -1,5 +1,7 @@
 import requests
 from typing import List
+from bs4 import BeautifulSoup
+
 from lib.func import get_logger, save_torrent_to_tempfile
 from models.BotConfigurator import BotConfigurator
 
@@ -21,11 +23,15 @@ class SearchBase:
     def get_status(self):
         pass
 
+    def get_data(self, search_string: str):
+        self.log.info("Searching for %s on %s", search_string, self.TRACKER_NAME)
+        search_url = self.TRACKER_URL+self.TRACKER_SEARCH_URL_TPL+search_string
+        return BeautifulSoup(self.session.get(search_url, timeout=10).content, 'lxml')
+
     @property
     def session(self) -> requests.Session:
         if self._session:
             return self._session
-
 
         self._session = requests.Session()
         self._session.headers.update(
@@ -60,7 +66,7 @@ class SearchBase:
                 'sid': '',
                 'login': 'Login'
             }
-            self._session.post(self.TRACKER_LOGIN_URL, data=payload)
+            self._session.post(self.TRACKER_LOGIN_URL, data=payload, timeout=10)
 
         return self._session
 

--- a/models/SearchKAT.py
+++ b/models/SearchKAT.py
@@ -13,8 +13,7 @@ class SearchKAT(SearchBase):
         logger = logging.getLogger(self.__class__.__name__)
         """Search data on the web"""
         self.POSTS=[]
-        x=self.TRACKER_URL+self.TRACKER_SEARCH_URL_TPL+search_string
-        _data=BeautifulSoup(get(x).content, 'lxml').select('table.data > tr.odd')
+        _data = self.get_data(search_string)..select('table.data > tr.odd')
         logger.debug(_data)
         for row in _data:
             _cols=row.select('td')

--- a/models/SearchKAT.py
+++ b/models/SearchKAT.py
@@ -13,7 +13,7 @@ class SearchKAT(SearchBase):
         logger = logging.getLogger(self.__class__.__name__)
         """Search data on the web"""
         self.POSTS=[]
-        _data = self.get_data(search_string)..select('table.data > tr.odd')
+        _data = self.get_data(search_string).select('table.data > tr.odd')
         logger.debug(_data)
         for row in _data:
             _cols=row.select('td')

--- a/models/SearchNonameClub.py
+++ b/models/SearchNonameClub.py
@@ -17,10 +17,8 @@ class SearchNonameClub(SearchBase):
 
     def search(self, search_string: str) -> List:
         """Search data on the web"""
-        self.log.info("Searching for %s on %s", search_string, self.TRACKER_NAME)
-        x = self.TRACKER_URL+self.TRACKER_SEARCH_URL_TPL+search_string
 
-        _data = BeautifulSoup(self.session.get(x).content, 'lxml').select('table.forumline > tbody > tr')
+        _data = self.get_data(search_string).select('table.forumline > tbody > tr')
         self.log.debug(_data)
         self.log.info("Found %s posts", len(_data))
 

--- a/models/SearchNonameClub.py
+++ b/models/SearchNonameClub.py
@@ -56,6 +56,8 @@ class SearchNonameClub(SearchBase):
                     'seed': SEEDS,
                     'leach': LEACH})
             except Exception as e:
+                # seems that there is some problem with this tr, let's just continue to the next one
+                # self.log.warning(_cols)
                 self.log.critical(e, exc_info=True)
-                raise e
+                pass
         return posts

--- a/models/SearchRUTOR.py
+++ b/models/SearchRUTOR.py
@@ -35,9 +35,7 @@ class SearchRUTOR(SearchBase):
     def search(self, search_string: str) -> List:
         """Search data on the web"""
 
-        self.log.info("Searching for %s on %s", search_string, self.TRACKER_NAME)
-        search_url = self.TRACKER_URL+self.TRACKER_SEARCH_URL_TPL+search_string
-        _data = BeautifulSoup(self.session.get(search_url).content, 'lxml').select('div#index > table > tr')
+        _data = self.get_data(search_string).select('div#index > table > tr')
         self.log.info("Found %s posts", len(_data) - 1)
 
         posts = []

--- a/models/SearchRutracker.py
+++ b/models/SearchRutracker.py
@@ -24,10 +24,7 @@ class SearchRutracker(SearchBase):
 
     def search(self, search_string: str) -> List:
         """Search data on the web"""
-        self.log.info("Searching for %s on %s", search_string, self.TRACKER_NAME)
-        x = self.TRACKER_URL+self.TRACKER_SEARCH_URL_TPL+search_string
-
-        _data = BeautifulSoup(self.session.get(x).content, 'lxml').select('table.forumline > tbody > tr')
+        _data = self.get_data(search_string).select('table.forumline > tbody > tr')
         self.log.debug(_data)
         self.log.info("Found %s posts", len(_data))
 

--- a/models/SearchRutracker.py
+++ b/models/SearchRutracker.py
@@ -2,11 +2,18 @@ from bs4 import BeautifulSoup
 from models.SearchBase import SearchBase
 from typing import List
 
-class SearchNonameClub(SearchBase):
-    TRACKER_NAME = "nnmclub"
-    TRACKER_URL = "https://nnmclub.to"
+class SearchRutracker(SearchBase):
+    TRACKER_NAME = "rutracker"
+    TRACKER_URL = "https://rutracker.org"
     TRACKER_SEARCH_URL_TPL = "/forum/tracker.php?nm="
-    TRACKER_LOGIN_URL = "https://nnmclub.to/forum/login.php"
+    TRACKER_LOGIN_URL = "https://rutracker.org/forum/login.php"
+    TRACKER_LOGIN_FIELDS = {
+        "username":"login_username", 
+        "password":"login_password", 
+        "meta":{
+            "login":None
+            }
+        }
 
     def convert_date(self, date: str) -> str:
         try:
@@ -28,22 +35,13 @@ class SearchNonameClub(SearchBase):
         for row in _data:
             try:
                 _cols = row.select('td')
-                TITLE = _cols[2].text.replace(r'<', '')
-                INFO = _cols[2].select('a')[0].get('href')
-                DL = _cols[4].select('a')[0].get('href')
-                SIZE = "".join(_cols[5].text.split(' ')[1:])
+                INFO = _cols[3].select('a')[0].get('href')
+                TITLE = _cols[3].text.replace(r'<', '').strip()
+                DL = _cols[5].select('a')[0].get('href')
+                SIZE = "".join(_cols[5].text.split(' ')[0])
                 DATE = "".join(_cols[9].text.split(' ')[1:])[0:10]
-                authorized = False
-                for key in self.session.cookies.get_dict().keys():
-                    if key.startswith("phpbb2mysql"):
-                        authorized = True
-                if authorized:
-                    SEEDS = _cols[7].text
-                    LEACH = _cols[8].text
-                else:
-                    SEEDS = _cols[6].text
-                    LEACH = _cols[7].text
-                self.log.info(f"Found seeds: {SEEDS}, leaches: {LEACH}")
+                SEEDS = _cols[6].text.replace(r'\n', '').strip()
+                LEACH = _cols[7].text.replace(r'\n', '').strip()
                 self.log.debug(f"COL T: {TITLE} L:{str(INFO)} DL:{str(DL)} S:{str(SIZE)} D:{str(DATE)}")
 
                 posts.append({
@@ -56,6 +54,9 @@ class SearchNonameClub(SearchBase):
                     'seed': SEEDS,
                     'leach': LEACH})
             except Exception as e:
+                # seems that there is some problem with this tr, let's just continue to the next one
+                # self.log.warning(_cols)
                 self.log.critical(e, exc_info=True)
-                raise e
+                pass
+
         return posts

--- a/models/SearchToloka.py
+++ b/models/SearchToloka.py
@@ -6,14 +6,11 @@ from typing import List
 class SearchToloka(SearchBase):
     TRACKER_NAME = 'toloka'
     TRACKER_URL = "https://toloka.to"
-    TRACKER_SEARCH_URL_TPL = "https://toloka.to/tracker.php?nm="
+    TRACKER_SEARCH_URL_TPL = "/tracker.php?nm="
     TRACKER_LOGIN_URL = "https://toloka.to/login.php"
 
     def search(self, search_string: str) -> List:
-        self.log.info("Searching for %s on %s", search_string, self.TRACKER_NAME)
-
-        raw_data = self.session.get(f"{self.TRACKER_SEARCH_URL_TPL}{search_string}")
-        _data = BeautifulSoup(raw_data.content, 'lxml').select('table.forumline')
+        _data = self.get_data(search_string).select('table.forumline')
 
         if len(_data) != 2:
             return False

--- a/models/SearchTorrents.py
+++ b/models/SearchTorrents.py
@@ -36,10 +36,10 @@ class SearchTorrents:
     CLASSES = {
         "nnmclub": SearchNonameClub,
         "rutracker": SearchRutracker,
-        # "rutor": SearchRUTOR,
+        "rutor": SearchRUTOR,
         # FIXME: Check KAT is alive or dead
         # "kat": SearchKAT,
-        # "toloka": SearchToloka
+        "toloka": SearchToloka
     }
     # Variable for storing search results
     CACHE = {}

--- a/models/SearchTorrents.py
+++ b/models/SearchTorrents.py
@@ -3,6 +3,7 @@ import pydash as _
 import time
 from typing import List, Dict
 from models.SearchNonameClub import SearchNonameClub
+from models.SearchRutracker import SearchRutracker
 from models.SearchRUTOR import SearchRUTOR
 from models.SearchBase import SearchBase
 # TODO: KAT is down, temporary disabled
@@ -32,11 +33,14 @@ class SearchTorrents:
     # TODO: For 2-factor auth we need to implement authentication with phpbb tokens
     CREDENTIALS = {}
     # List of enabled trackers
-    CLASSES = {"nnmclub": SearchNonameClub,
-               "rutor": SearchRUTOR,
-               # FIXME: Check KAT is alive or dead
-               # "kat": SearchKAT,
-               "toloka": SearchToloka}
+    CLASSES = {
+        "nnmclub": SearchNonameClub,
+        "rutracker": SearchRutracker,
+        "rutor": SearchRUTOR,
+        # FIXME: Check KAT is alive or dead
+        # "kat": SearchKAT,
+        "toloka": SearchToloka
+    }
     # Variable for storing search results
     CACHE = {}
     CACHE_TIMER = {}

--- a/models/SearchTorrents.py
+++ b/models/SearchTorrents.py
@@ -36,10 +36,10 @@ class SearchTorrents:
     CLASSES = {
         "nnmclub": SearchNonameClub,
         "rutracker": SearchRutracker,
-        "rutor": SearchRUTOR,
+        # "rutor": SearchRUTOR,
         # FIXME: Check KAT is alive or dead
         # "kat": SearchKAT,
-        "toloka": SearchToloka
+        # "toloka": SearchToloka
     }
     # Variable for storing search results
     CACHE = {}

--- a/templates/torrentino.docker.yaml
+++ b/templates/torrentino.docker.yaml
@@ -51,3 +51,12 @@ trackers:
   toloka:
     user: <email or login>
     password: <password>
+  rutracker:
+    user: <email or login>
+    password: <password>
+
+# Proxies
+proxy:
+  enabled: False
+  url: 127.0.0.1:7777
+

--- a/templates/torrentino.sample.yaml
+++ b/templates/torrentino.sample.yaml
@@ -61,3 +61,12 @@ trackers:
   toloka:
     user: <email or login>
     password: <password>
+  rutracker:
+    user: <email or login>
+    password: <password>
+
+# Proxies
+proxy:
+  enabled: False
+  url: 127.0.0.1:7777
+

--- a/templates/torrentino.template.yaml
+++ b/templates/torrentino.template.yaml
@@ -61,3 +61,12 @@ trackers:
   toloka:
     user: <email or login>
     password: <password>
+  rutracker:
+    user: <email or login>
+    password: <password>
+
+# Proxies
+proxy:
+  enabled: False
+  url: 127.0.0.1:7777
+


### PR DESCRIPTION
Hi, thanks for your bot!

I've decided to use it in home NAS system and thus there are some small fixes from me. 

First of all I added Rutracker, as it's quite famous and popular. 
For that I also had to debug some traffic, thus there's a new option - proxy. 
I thought of removing it, but some users can use proxy for other stuff - so it can stay.
Also, Rutracker has different login and password fields, so I had to take care of that. 

Added useragent to the session just in case.

Also there's a small update on final rendering - I've decided that it's a good idea to reveal the tracker to the user, so i've changed "info" link to "tracker_name" link.
Added a '\n' so it looks a bit more tidy

Also I've created a dockerfile (Dockerfile.nas), that is build with a built-in configuration file

